### PR TITLE
Adds missing argument to the code snippet in Chapter 8

### DIFF
--- a/manuscript-en/08-abstraction.md
+++ b/manuscript-en/08-abstraction.md
@@ -372,7 +372,7 @@ async function submitLoginForm(event) {
   const data = serializeForm(form);
   if (!isValidLogin(data)) return;
 
-  return await loginUser();
+  return await loginUser(data);
 }
 ```
 

--- a/manuscript-ru/08-abstraction.md
+++ b/manuscript-ru/08-abstraction.md
@@ -373,7 +373,7 @@ async function submitLoginForm(event) {
   const data = serializeForm(form);
   if (!isValidLogin(data)) return;
 
-  return await loginUser();
+  return await loginUser(data);
 }
 ```
 


### PR DESCRIPTION
The function `loginUser` takes argument, but it is missing in the call.