### PR TITLE
Fix parseUser and meaning of throwing error sentence

### DIFF
--- a/manuscript-en/12-error-handling.md
+++ b/manuscript-en/12-error-handling.md
@@ -87,9 +87,9 @@ async function fetchUser(url) {
 The `parseUser` function parses the server response and returns the user object or `null` if the DTO is invalid:
 
 ```js
-function parseUser(dto: UserDto): User {
+function parseUser(dto: UserDto): User | null {
   if (!dto || !dto.firstName || !dto.lastName || !dto.email) return null;
-  return { ...dto, fullName: `${firstName} ${lastName}` };
+  return { ...dto, fullName: `${dto.firstName} ${dto.lastName}` };
 }
 ```
 

--- a/manuscript-ru/12-error-handling.md
+++ b/manuscript-ru/12-error-handling.md
@@ -86,9 +86,9 @@ async function fetchUser(url) {
 Функция `parseUser` парсит серверный ответ и возвращает объект пользователя или `null`, если DTO оказался невалидным:
 
 ```js
-function parseUser(dto: UserDto): User {
+function parseUser(dto: UserDto): User | null {
   if (!dto || !dto.firstName || !dto.lastName || !dto.email) return null;
-  return { ...dto, fullName: `${firstName} ${lastName}` };
+  return { ...dto, fullName: `${dto.firstName} ${dto.lastName}` };
 }
 ```
 
@@ -118,7 +118,7 @@ async function fetchUser(url) {
 }
 ```
 
-Мы можем это решить, добавив обработку через `try-catch` на уровне выше. Выброшенная ошибка в функции `getUser` будет перехвачена, и мы сможем её обработать:
+Мы можем это решить, добавив обработку через `try-catch` на уровне выше. Выброшенная ошибка будет перехвачена в функции `getUser`, и мы сможем её обработать:
 
 ```js
 async function getUser(id) {


### PR DESCRIPTION
> Выброшенная ошибка в функции getUser будет перехвачена, и мы сможем её обработать:

Тут читается так, как будто ошибка будет выброшена в getUser, а на самом деле её выбросит fetchUser. Думаю, лучше поправить текст. В английской версии читается нормально

> Then the getUser function will catch the thrown error, and we'll be able to handle it: