### PR TITLE
Fix example: 12-error-handling.md[RU/EN]

### DIFF
--- a/manuscript-en/12-error-handling.md
+++ b/manuscript-en/12-error-handling.md
@@ -188,8 +188,8 @@ class InvalidUserDto extends Error {
 // API errors:
 class NetworkError extends Error {
   constructor(message, status, traceId) {
+    super(message ?? messageFromStatus(status));
     this.name = this.constructor.name;
-    this.message = message ?? messageFromStatus(status);
 
     // We can extend the type with additional fields for logging:
     this.status = status;

--- a/manuscript-ru/12-error-handling.md
+++ b/manuscript-ru/12-error-handling.md
@@ -187,8 +187,8 @@ class InvalidUserDto extends Error {
 // Ошибки API:
 class NetworkError extends Error {
   constructor(message, status, traceId) {
+    super(message ?? messageFromStatus(status));
     this.name = this.constructor.name;
-    this.message = message ?? messageFromStatus(status);
 
     // Можно расширить дополнительными полями для логирования:
     this.status = status;


### PR DESCRIPTION
Чтобы в подклассе получить доступ к this, необходимо перед этим вызвать конструктор базового класса, верно?
`Uncaught ReferenceError: Must call super constructor in derived class before accessing 'this' or returning from derived constructor`